### PR TITLE
Add ActivityWatch MCP server for ChatGPT connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ActivityWatch MCP Server
+
+This repository provides a [Model Context Protocol](https://platform.openai.com/docs/mcp) server that exposes your local [ActivityWatch](https://activitywatch.net/) data to ChatGPT.
+
+## Tools
+- **search** – find window events whose titles match a query
+- **fetch** – retrieve the full JSON for a result returned by `search`
+
+These tools follow the ChatGPT connector requirements and can be added as a custom connector in ChatGPT.
+
+## Requirements
+- Python 3.11+
+- ActivityWatch running on `http://localhost:5600`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Run the MCP server:
+
+```bash
+python server.py
+```
+
+The server listens on `http://localhost:3000`. Configure ChatGPT to connect to this endpoint as an MCP server and use the `search` and `fetch` tools to query your ActivityWatch data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+httpx


### PR DESCRIPTION
## Summary
- Expose ActivityWatch data through MCP server with ChatGPT-compatible `search` and `fetch` tools
- Document setup and usage for connecting ActivityWatch to ChatGPT

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6896fba322788323bac8d5bfd5566068