### PR TITLE
Add ActivityWatch MCP server for ChatGPT connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ActivityWatch MCP Server
+
+This repository provides a [Model Context Protocol](https://platform.openai.com/docs/mcp) server that exposes your local [ActivityWatch](https://activitywatch.net/) data to ChatGPT using the official [`aw-client`](https://github.com/ActivityWatch/aw-client) library.
+
+## Tools
+- **search** – find window events whose titles match a query
+- **fetch** – retrieve the full JSON for a result returned by `search`
+
+These tools follow the ChatGPT connector requirements and can be added as a custom connector in ChatGPT.
+
+## Requirements
+- Python 3.11+
+- ActivityWatch running on `http://localhost:5600`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Run the MCP server:
+
+```bash
+python server.py [--aw-host HOST] [--aw-port PORT] [--port MCP_PORT] [--debug]
+```
+
+The server listens on `http://localhost:3000` by default. Configure ChatGPT to connect to this endpoint as an MCP server and use the `search` and `fetch` tools to query your ActivityWatch data. Passing `--debug` will print tool inputs and outputs so you can see exactly what ChatGPT receives.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastmcp
+aw-client

--- a/server.py
+++ b/server.py
@@ -1,58 +1,147 @@
 import json
-from pathlib import Path
-from dataclasses import dataclass
+import json
+import asyncio
+from datetime import datetime
+from typing import Dict, Optional
+
+from aw_client.client import ActivityWatchClient
 from fastmcp import FastMCP
 
-@dataclass
-class Record:
-    id: str
-    title: str
-    text: str
-    metadata: dict
+# cache of search results so fetch can return full data
+SEARCH_CACHE: Dict[str, dict] = {}
+
 
 def create_server(
-    records_path: Path | str,
-    name: str | None = None,
-    instructions: str | None = None,
+    aw_host: str = "localhost",
+    aw_port: int = 5600,
+    name: Optional[str] = None,
+    instructions: Optional[str] = None,
+    debug: bool = False,
 ) -> FastMCP:
-    """Create a FastMCP server that can search and fetch records from a JSON file."""
-    records = json.loads(Path(records_path).read_text())
+    """Create a FastMCP server exposing ActivityWatch search and fetch tools."""
 
-    RECORDS = [Record(**r) for r in records]
-    LOOKUP = {r.id: r for r in RECORDS}
+    mcp = FastMCP(
+        name=name or "ActivityWatch MCP",
+        instructions=instructions or "Search and fetch ActivityWatch window events.",
+    )
 
-    mcp = FastMCP(name=name or "Deep Research MCP", instructions=instructions)
+    client = ActivityWatchClient("aw-mcp", host=aw_host, port=aw_port)
 
     @mcp.tool()
-    async def search(query: str):
-        """
-        Simple unranked keyword search across title, text, and metadata.
-        Searches for any of the query terms in the record content.
-        Returns a list of matching record IDs for ChatGPT to fetch.
-        """
-        toks = query.lower().split()
-        ids = []
-        for r in RECORDS:
-            record_txt = " ".join(
-                [r.title, r.text, " ".join(r.metadata.values())]
-            ).lower()
-            if any(t in record_txt for t in toks):
-                ids.append(r.id)
+    async def search(query: str, limit: int = 5, cursor: Optional[str] = None):
+        """Search window events by title using ActivityWatch."""
+        offset = int(cursor) if cursor else 0
+        matches: list[dict] = []
+        try:
+            buckets = await asyncio.to_thread(client.get_buckets)
+            for bucket_id, data in buckets.items():
+                if data.get("type") != "aw-watcher-window":
+                    continue
+                events = await asyncio.to_thread(client.get_events, bucket_id, 500)
+                for ev in events:
+                    title = ev.data.get("title", "")
+                    if query.lower() in title.lower():
+                        ts = ev.timestamp.isoformat()
+                        result_id = f"{bucket_id}:{ts}"
+                        SEARCH_CACHE[result_id] = {
+                            "bucket": bucket_id,
+                            "event": ev.to_json_dict(),
+                        }
+                        matches.append(
+                            {
+                                "id": result_id,
+                                "title": title,
+                                "url": f"activitywatch://{bucket_id}/{ts}",
+                            }
+                        )
+        except Exception as e:
+            return {
+                "content": [{"type": "text", "text": f"Search failed: {e}"}],
+                "isError": True,
+            }
 
-        return {"ids": ids}
+        paginated = matches[offset : offset + limit]
+        next_cursor = str(offset + limit) if offset + limit < len(matches) else None
+        result = {"results": paginated, "next_cursor": next_cursor}
+        if debug:
+            print(
+                json.dumps(
+                    {
+                        "tool": "search",
+                        "input": {"query": query, "limit": limit, "cursor": cursor},
+                        "output": result,
+                    },
+                    indent=2,
+                )
+            )
+        return result
 
     @mcp.tool()
     async def fetch(id: str):
-        """
-        Fetch a record by ID.
-        Returns the complete record data for ChatGPT to analyze and cite.
-        """
-        if id not in LOOKUP:
-            raise ValueError(f"Unknown record ID: {id}")
-        return LOOKUP[id]
+        """Fetch full event JSON for a search result."""
+        data = SEARCH_CACHE.get(id)
+        if data is None:
+            try:
+                bucket, ts = id.split(":", 1)
+                dt = datetime.fromisoformat(ts)
+                events = await asyncio.to_thread(
+                    client.get_events, bucket, 1, dt, dt
+                )
+                if not events:
+                    return {
+                        "content": [
+                            {"type": "text", "text": "Event not found"}
+                        ],
+                        "isError": True,
+                    }
+                ev = events[0].to_json_dict()
+            except ValueError:
+                return {
+                    "content": [{"type": "text", "text": "Invalid id"}],
+                    "isError": True,
+                }
+            except Exception as e:
+                return {
+                    "content": [{"type": "text", "text": f"Fetch failed: {e}"}],
+                    "isError": True,
+                }
+        else:
+            bucket = data["bucket"]
+            ev = data["event"]
+
+        result = {
+            "id": id,
+            "title": ev.get("data", {}).get("title", ""),
+            "url": f"activitywatch://{bucket}/{ev['timestamp']}",
+            "content": [{"type": "text", "text": json.dumps(ev, indent=2)}],
+        }
+        if debug:
+            print(
+                json.dumps(
+                    {
+                        "tool": "fetch",
+                        "input": {"id": id},
+                        "output": result,
+                    },
+                    indent=2,
+                )
+            )
+        return result
 
     return mcp
 
+
 if __name__ == "__main__":
-    mcp = create_server("path/to/records.json")
-    mcp.run(transport="http", port=3344)
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--aw-host", default="localhost")
+    parser.add_argument("--aw-port", type=int, default=5600)
+    parser.add_argument("--port", type=int, default=3000, help="MCP server port")
+    parser.add_argument("--debug", action="store_true", help="Print tool IO")
+    args = parser.parse_args()
+
+    server = create_server(
+        aw_host=args.aw_host, aw_port=args.aw_port, debug=args.debug
+    )
+    server.run(transport="http", port=args.port)


### PR DESCRIPTION
## Summary
- Retrieve ActivityWatch data via official aw-client library
- Add `--debug` flag and CLI options to inspect tool inputs/outputs
- Document aw-client usage and new debug instructions

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6896fba322788323bac8d5bfd5566068